### PR TITLE
Sm03lebr00t/feature/simplelogger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,17 +28,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,19 +290,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "env_logger"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,12 +376,6 @@ name = "httparse"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
-
-[[package]]
-name = "humantime"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "idna"
@@ -1259,7 +1229,6 @@ name = "twitch-discord-bot"
 version = "0.1.0"
 dependencies = [
  "config",
- "env_logger",
  "log",
  "native-tls",
  "notify-rust",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1081,6 +1081,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "simplelog"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2736f58087298a448859961d3f4a0850b832e72619d75adc69da7993c2cd3c"
+dependencies = [
+ "chrono",
+ "log",
+ "termcolor",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,11 +1260,13 @@ version = "0.1.0"
 dependencies = [
  "config",
  "env_logger",
+ "log",
  "native-tls",
  "notify-rust",
  "rand",
  "serde 1.0.117",
  "serde_json",
+ "simplelog",
  "tungstenite",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2018"
 [dependencies]
 tungstenite = "0.11.1"
 env_logger = "0.8.1"
+log = "0.4.11"
+simplelog = "0.8.0"
 url = "2.2.0"
 rand = "0.7.3"
 serde = { version = "1.0.117", features = ["derive"] }
@@ -16,4 +18,5 @@ serde_json = "1.0.59"
 notify-rust = { version = "4.0.0", features = ["images"] }
 native-tls = "0.2.5"
 config = "0.10.1"
+
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 tungstenite = "0.11.1"
-env_logger = "0.8.1"
 log = "0.4.11"
 simplelog = "0.8.0"
 url = "2.2.0"

--- a/src/channel_points_redemption.rs
+++ b/src/channel_points_redemption.rs
@@ -6,6 +6,8 @@ use notify_rust::Hint;
 use notify_rust::Image;
 use notify_rust::Notification;
 
+use log::*;
+
 use std::process::Command;
 
 use crate::common_structs::{Res, Msg};
@@ -16,6 +18,9 @@ pub fn channel_points_redemption(res_msg: &Res) {
         .expect("Could not deserialize Channel Points data message");
 
     let redemption_title = &redemption_msg.data.redemption.reward.title;
+
+    // logging redemtion [info]
+    log!(format!("<{}> redeemed {}", &redemption_msg.data.redemption.user, redemption_title));
 
     if redemption_title.contains("Hydrate!") {
         // Send notification for hydration events

--- a/src/chat_command.rs
+++ b/src/chat_command.rs
@@ -7,6 +7,7 @@ pub mod chat_commands {
     use std::net::TcpStream;
     use tungstenite::stream::Stream;
     use tungstenite::WebSocket;
+    use log::*;
 
     pub fn cmd_response(
         msg: TwitchChatMsg,
@@ -19,7 +20,7 @@ pub mod chat_commands {
             .try_into::<HashMap<String, String>>()
             .expect("Could not parse commands file");
 
-        println!("{}", msg.message);
+        log!(format!("<{}>: {}", msg.display_name, msg.message));
         for (command_key, command_res) in parsed_commands.iter() {
             if msg.message.trim().eq(command_key) {
                 send_msg(socket, &msg.channel_name, command_res.to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,9 @@
 #![warn(clippy::nursery)]
 use config::{Config, File};
 
+use log::LevelFilter;
 use serde_json::Result;
+use simplelog::*;
 
 use std::time::Duration;
 
@@ -13,7 +15,13 @@ use twitch_discord_bot::{
 };
 
 fn main() -> Result<()> {
-    env_logger::init();
+    // Initialize logger here
+    CombinedLogger::init(
+        vec![
+            TermLogger::new(LevelFilter::Warn, Config::default(), TerminalMode::Mixed),
+            WriteLogger::new(LevelFilter::Info, Config::default(), File::create("twitch-discord-bot.log").unwrap()),
+        ]
+    ).unwrap();
 
     let mut settings = Config::default();
     let mut commands = Config::default();
@@ -37,6 +45,7 @@ fn main() -> Result<()> {
     twitch_pubsub_bot.send_listen_msg();
     discord_bot.setup();
 
+    info!("Starting bot ...");
     std::thread::sleep(Duration::from_millis(200));
     loop {
 

--- a/src/new_follower.rs
+++ b/src/new_follower.rs
@@ -10,6 +10,8 @@ use std::process::Command;
 
 use crate::common_structs::{Res, MetaMsg};
 
+use log::*;
+
 #[derive(Deserialize, Serialize)]
 struct NewFollower {
     display_name: String,
@@ -20,7 +22,7 @@ struct NewFollower {
 pub fn new_follower(res_msg: &Res) {
     let new_follower: NewFollower = serde_json::from_str(res_msg.data.message.as_str()).expect("No json");
 
-    println!("{}", serde_json::to_string(&new_follower).expect(""));
+    log!(format!("{}", serde_json::to_string(&new_follower).expect("")));
 
 // Res {
 //    event: "MESSAGE",

--- a/src/send_msg.rs
+++ b/src/send_msg.rs
@@ -13,6 +13,6 @@ pub fn send_msg(
 
     let msg = format!("{}{}", msg_id, msg);
 
-    println!("Sending message:\n{}\n", &msg);
+    info!("Sending message: {}", &msg);
     ws_chat.write_message(Message::Text(msg)).unwrap()
 }


### PR DESCRIPTION
## What does this do?

This replaces the `env_logger` with `simplelog`. You can now easily log via the `error!, warn!, info!, trace!, debug!, log` macros. 

Currently configured to use a file log and a terminal log, replacing all used `println!` macros. Also on some points output has been modified.

## What can be improved?

- [ ] idk if all the logging info is how you like it, please review these and change them to your will
- [ ] trying to test on my windows I had some problems with missing crates, please test on your env to ensure it will work